### PR TITLE
Small README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ update model msg =
                 |> MultiWaitable.wait3Update1 user
                 |> Tuple.mapFirst Loading
 
-        ( Loading waitable, UserOptions options ) ->
+        ( Loading waitable, OptionsFetched options ) ->
             waitable
                 |> MultiWaitable.wait3Update2 options
                 |> Tuple.mapFirst Loading


### PR DESCRIPTION
Hey, thanks for a nice package

I have found that you were using `UserOptions` msg in the README which is not defined. It doesn't made sense to me, so if I'm understanding the code correctly, it should be like this.

Also, maybe it would be nice to know where the `XYZFetched` messages get from when you use MultiWaitable with only `Msg User Options Bookmarks` but there is no mention of those `Msg` with `Fetched` suffix anywhere.